### PR TITLE
push version jump down into minor version

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,5 +1,5 @@
 name: Cabal
-version: 1000.24.2.0
+version: 1.24.1002.0
 copyright: 2003-2006, Isaac Jones
            2005-2011, Duncan Coutts
 license: BSD3


### PR DESCRIPTION
This keeps us out of the way of changes made to support later Cabal versions.